### PR TITLE
Fix printing failed command output

### DIFF
--- a/files/generate-certs
+++ b/files/generate-certs
@@ -76,7 +76,7 @@ def main(argv):
             print output
         except subprocess.CalledProcessError, err:
             if err.returncode != 1:
-                print output
+                print err.output
             if err.returncode >= 2:
                 raise RuntimeError(
                     "Unable to generate certificates for " + vhost["domains"][0]


### PR DESCRIPTION
it should be the output from the exception, otherwise we get random output from the previous vhost...
