### PR TITLE
Support running a command when a cert is renewed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ansible-role-simp_le
 Install [simp_le](https://github.com/kuba/simp_le.git), generate certificates
 and renew them automatically on Debian/Ubuntu servers.
 
-Renewal happens every month via a cron job run by the Ansible remote user.
+Renewal will be attempted daily via a cron job run by the Ansible remote user.
 
 See the role on Ansible Galaxy: [L-P.simp_le](https://galaxy.ansible.com/detail#/role/6627)
 
@@ -30,6 +30,8 @@ There are three optional keys you can set on hosts:
   renewing the certificate. This is useful if you are using TLSA records, you
   can then use Selector type 1 (SubjectPublicKeyInfo) and your TLSA record will
   not need changing when the certificate is renewed.
+- `update_action` a command to be run when a certificate is renewed,
+   e.g. `systemctl restart apache2`
 
 Example:
 ```yaml
@@ -40,6 +42,7 @@ simp_le_vhosts:
     user: "Debian-exim"
     group: "Debian-exim"
     extra_args: "--reuse_key --server https://acme-staging.api.letsencrypt.org/directory"
+    update_action: "/bin/systemctl restart exim4"
 ```
 
 See `defaults/main.yml` for more configuration.

--- a/files/generate-certs
+++ b/files/generate-certs
@@ -70,6 +70,7 @@ def main(argv):
         # simp_le returns 1 when a renewal is not needed
         # to avoid getting loads of emails when this script is run from cron
         # ignore returncode == 1
+        updated = True
         try:
             output = subprocess.check_output(cmd, cwd=vhost["output"],
                                              stderr=subprocess.STDOUT)
@@ -77,11 +78,28 @@ def main(argv):
         except subprocess.CalledProcessError, err:
             if err.returncode != 1:
                 print err.output
+            if err.returncode == 1:
+                updated = False
             if err.returncode >= 2:
                 raise RuntimeError(
                     "Unable to generate certificates for " + vhost["domains"][0]
                 )
+                updated = False
         create_certkey(vhost["output"])
+        if updated:
+            if "update_action" in vhost:
+                print "Certificate updated for (", ",".join(vhost["domains"]), ")"
+                print "running ", vhost["update_action"]
+                try:
+                    output = subprocess.check_output(vhost["update_action"].split(" "), cwd=vhost["output"],
+                                             stderr=subprocess.STDOUT)
+                    print output
+                except subprocess.CalledProcessError, err:
+                    print "Update action failed:"
+                    print err.output
+                except OSError, err: # e.g. file not found
+                    print "Update action failed:"
+                    print err
 
 if __name__ == "__main__":
     main(sys.argv)


### PR DESCRIPTION
When a certificate is renewed we need to restart the services that uses
it otherwise it will continue to use the old cert.

This commit adds an extra optional config item "update_action" that contains
a command to be run by the generate-certs script if a certificate is
renewed.
