### PR TITLE
Always install latest pip, setuptools version

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,6 +34,7 @@
     virtualenv="{{simp_le_dest}}/venv"
     name="{{item}}"
     chdir="{{simp_le_dest}}"
+    state=latest
   with_items: "{{simp_le_python_dependencies}}"
 
 - name: Setup simp_le.


### PR DESCRIPTION
On an old distro (Debian Wheezy), the old pip and distribute version might create this issue:
    AttributeError: 'module' object has no attribute 'evaluate_marker'

This makes sure we have the latest pip.